### PR TITLE
Fix polling hanging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dialectlabs/monitor",
-  "version": "1.2.7",
+  "version": "1.2.10",
   "repository": "git@github.com:dialectlabs/monitor.git",
   "author": "dialectlabs",
   "license": "Apache-2.0",


### PR DESCRIPTION
For some reason the promise returned from poll() sometimes stucks and becomes infinitely pending when data is fetched using solana web3 client. Not sure, but may be somehow related to connection state management in solana/web3 + RPC pool combination

This should fix the issue: was tested during the last night