### PR TITLE
Allows to set a limit that is over/under the rise/fall at which to not trigger

### DIFF
--- a/src/transformation-pipeline-operators.ts
+++ b/src/transformation-pipeline-operators.ts
@@ -116,6 +116,7 @@ export class Operators {
   static Trigger = class {
     static risingEdge<T extends object>(
       threshold: number,
+      limit?: number,
     ): [
       OperatorFunction<Data<number, T>, Data<number, T>[]>,
       OperatorFunction<Data<number, T>[], Data<number, T>[]>,
@@ -127,7 +128,7 @@ export class Operators {
           (it) =>
             it.length === 2 &&
             it[0].value <= threshold &&
-            threshold < it[1].value,
+            threshold < it[1].value && (!limit || it[1].value < limit),
         ),
         map(([_, snd]) => snd),
       ];
@@ -135,6 +136,7 @@ export class Operators {
 
     static fallingEdge<T extends object>(
       threshold: number,
+      limit?: number,
     ): [
       OperatorFunction<Data<number, T>, Data<number, T>[]>,
       OperatorFunction<Data<number, T>[], Data<number, T>[]>,
@@ -146,7 +148,7 @@ export class Operators {
           (data) =>
             data.length === 2 &&
             data[0].value >= threshold &&
-            threshold > data[1].value,
+            threshold > data[1].value && (!limit || data[1].value > limit),
         ),
         map(([_, snd]) => snd),
       ];

--- a/src/transformation-pipelines.ts
+++ b/src/transformation-pipelines.ts
@@ -24,11 +24,13 @@ export type Trigger =
 export interface RisingEdgeTrigger {
   type: 'rising-edge';
   threshold: number;
+  limit?: number;
 }
 
 export interface FallingEdgeTrigger {
   type: 'falling-edge';
   threshold: number;
+  limit?: number;
 }
 
 export interface IncreaseTrigger {
@@ -51,9 +53,9 @@ export interface ThrottleTimeRateLimit {
 function createTriggerOperator<T extends object>(trigger: Trigger) {
   switch (trigger.type) {
     case 'falling-edge':
-      return Operators.Trigger.fallingEdge<T>(trigger.threshold);
+      return Operators.Trigger.fallingEdge<T>(trigger.threshold, trigger.limit);
     case 'rising-edge':
-      return Operators.Trigger.risingEdge<T>(trigger.threshold);
+      return Operators.Trigger.risingEdge<T>(trigger.threshold, trigger.limit);
     case 'increase':
       return Operators.Trigger.increase<T>(trigger.threshold);
     case 'decrease':


### PR DESCRIPTION
allows to set a limit that is over/under the rise/fall at which to not trigger.
useful when a monitor has several layers of thresholds and you don't want possibility of duplicate/erroneous messages sent when multiple thresholds passed at once. In production, it's probably a rare issue, but either way its available for future implementations.